### PR TITLE
Update toil to python3

### DIFF
--- a/Dockerfile.Toil
+++ b/Dockerfile.Toil
@@ -1,12 +1,12 @@
-FROM python:2.7
+FROM python:3.7
 
 # install toil
 RUN apt-get update && apt-get install -y libssl-dev libffi-dev
-RUN pip install toil[all]
-RUN pip install boto
-RUN pip install pandas
-RUN pip install docker
-RUN pip install synapseclient
+RUN pip3 install toil[all]
+RUN pip3 install boto
+RUN pip3 install pandas
+RUN pip3 install docker
+RUN pip3 install synapseclient
 # now install docker, following the instructions here: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce-1
 RUN apt-get update   
 

--- a/Dockerfile.Toil
+++ b/Dockerfile.Toil
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.6
 
 # install toil
 RUN apt-get update && apt-get install -y libssl-dev libffi-dev


### PR DESCRIPTION
* Python 2 is going to be deprecated soon.

Verified that this works.  I built this dockerfile and pushed the docker image to my own toil repo and set `WORKFLOW_ENGINE_DOCKER_IMAGE` to that repository. `thomasvyu/test-toil`

