### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile.Toil
+++ b/Dockerfile.Toil
@@ -31,7 +31,6 @@ RUN apt-get install -y docker-ce
 # RUN apt-get install -y nodejs npm
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
 RUN apt-get install -y nodejs
-# RUN apt-get install -y npm
 RUN npm install js-yaml
 
 RUN echo -e "\numask 000\n" >> ~/.profile

--- a/Dockerfile.Toil
+++ b/Dockerfile.Toil
@@ -2,7 +2,7 @@ FROM python:3.6
 
 # install toil
 RUN apt-get update && apt-get install -y libssl-dev libffi-dev
-RUN pip3 install toil[all]
+RUN pip3 install toil[all]==4.1.0
 RUN pip3 install boto
 RUN pip3 install pandas
 RUN pip3 install docker
@@ -29,10 +29,9 @@ RUN apt-get install -y docker-ce
 
 #install nodejs, to provide in line javascript evaluation
 # RUN apt-get install -y nodejs npm
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
 RUN apt-get install -y nodejs
-RUN apt-get install -y npm
-
+# RUN apt-get install -y npm
 RUN npm install js-yaml
 
 RUN echo -e "\numask 000\n" >> ~/.profile


### PR DESCRIPTION
* The most recent release of `toil-cwl-runner` breaks the challenge workflows that are running.  Lock down specific version of `toil` so that issues don't arise. 
* Update `nodejs` 
* `npm` is installed with `nodejs` so no need to install it.  