### PR TITLE
fix: update image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run:
 
 ```
 docker run --rm -it -e SYNAPSE_USERNAME=xxxxx -e SYNAPSE_PAT=xxxxx \
--e WORKFLOW_TEMPLATE_URL=http://xxxxxx -e ROOT_TEMPLATE=xxxxx ghcr.io/sage-bionetworks/synapseworkfloworchestrator /set_up.sh
+-e WORKFLOW_TEMPLATE_URL=http://xxxxxx -e ROOT_TEMPLATE=xxxxx ghcr.io/sage-bionetworks/synapseworkfloworchestrator:master /set_up.sh
 ```
 
 where `WORKFLOW_TEMPLATE_URL` is a link to a zip file and `ROOT_TEMPLATE` is a path within the zip where a workflow file can be found. To use a workflow in Dockstore:
@@ -46,7 +46,7 @@ where `WORKFLOW_TEMPLATE_URL` is a link to a zip file and `ROOT_TEMPLATE` is a p
 ```
 docker run --rm -it -e SYNAPSE_USERNAME=xxxxx -e SYNAPSE_PAT=xxxxx \
 -e WORKFLOW_TEMPLATE_URL=https://dockstore.org:8443/api/ga4gh/v2/tools/{id}/versions/{version_id}/CWL \
--e ROOT_TEMPLATE=xxxxx ghcr.io/sage-bionetworks/synapseworkfloworchestrator /set_up.sh
+-e ROOT_TEMPLATE=xxxxx ghcr.io/sage-bionetworks/synapseworkfloworchestrator:master /set_up.sh
 ```
 
 Will print out created Project ID and the value for the `EVALUATION_TEMPLATES` in the following step.

--- a/docker-compose-wes.yaml
+++ b/docker-compose-wes.yaml
@@ -1,7 +1,7 @@
 services:
   workflow-orchestrator:
     image:
-      ghcr.io/sage-bionetworks/synapseworkfloworchestrator:latest
+      ghcr.io/sage-bionetworks/synapseworkfloworchestrator:master
     volumes:
       - ${WES_SHARED_DIR_PROPERTY}:${WES_SHARED_DIR_PROPERTY}:rw
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ volumes:
 services:
   workflow-orchestrator:
     image:
-      ghcr.io/sage-bionetworks/synapseworkfloworchestrator:latest
+      ghcr.io/sage-bionetworks/synapseworkfloworchestrator:master
     restart: always
     volumes:
       - shared:/shared:rw


### PR DESCRIPTION
## Problem

It was presumed that `latest` would be available for the newly-built image, but this was not the case: https://github.com/Sage-Bionetworks/SynapseWorkflowOrchestrator/pkgs/container/synapseworkfloworchestrator

A different tag name would need to be specified instead.

## Changelog

* specify the tag `master` in the docker compose files and README